### PR TITLE
Add delete to subresource list

### DIFF
--- a/s3auth/v2.go
+++ b/s3auth/v2.go
@@ -32,6 +32,7 @@ import (
 // Whitelist resource list that will be used in query string for signature-V2 calculation.
 var resourceList = []string{
 	"acl",
+	"delete",
 	"lifecycle",
 	"location",
 	"logging",


### PR DESCRIPTION
According to the current [AWS S3 API documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#ConstructingTheCanonicalizedResourceElement) the delete query
string parameter must be included when you create the CanonicalizedResource
for a multi-object Delete request.